### PR TITLE
refactor!: extract Portal.Content as a class

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,9 +182,9 @@ Filter, match, and iterate over Neovim's [`:h changelist`](https://neovim.io/doc
 - **`type`**: `"changelist"`
 - **`buffer`**: `0`
 - **`cursor`**: the changelist `lnum` and `col`
-- **`select`**: uses native `g;` and `g,` to preserve changelist ordering
-- **`direction`**: the search [direction](#portaldirection)
-- **`distance`**: the absolute distance between the start and current changelist entry
+- **`extra.direction`**: the search [direction](#portaldirection)
+- **`extra.distance`**: the absolute distance between the start and current changelist entry
+- **`:select()`**: uses native `g;` and `g,` to preserve changelist ordering
 
 <details>
 <summary><b>Examples</b></summary>
@@ -211,8 +211,8 @@ Filter, match, and iterate over tagged files from [grapple](https://github.com/c
 - **`type`**: `"grapple"`
 - **`buffer`**: the file tags's `bufnr`
 - **`cursor`**: the file tags's `row` and `col`
-- **`select`**: uses `grapple#select`
-- **`key`**: the file tags's key
+- **`extra.key`**: the file tags's key
+- **`:select()`**: uses `grapple#select`
 
 <details>
 <summary><b>Examples</b></summary>
@@ -239,8 +239,8 @@ Filter, match, and iterate over marked files from [harpoon](https://github.com/T
 - **`type`**: `"harpoon"`
 - **`buffer`**: the file mark's `bufnr`
 - **`cursor`**: the file mark's `row` and `col`
-- **`select`**: uses `harpoon.ui#nav_file`
-- **`index`**: the file mark's index
+- **`extra.index`**: the file mark's index
+- **`:select()`**: uses `harpoon.ui#nav_file`
 
 <details>
 <summary><b>Examples</b></summary>
@@ -267,9 +267,9 @@ Filter, match, and iterate over Neovim's [`:h jumplist`](https://neovim.io/doc/u
 - **`type`**: `"jumplist"`
 - **`buffer`**: the jumplist `bufnr`
 - **`cursor`**: the jumplist `lnum` and `col`
-- **`select`**: uses native `<c-o>` and `<c-i>` to preserve jumplist ordering
-- **`direction`**: the search [direction](#portaldirection)
-- **`distance`**: the absolute distance between the start and current jumplist entry
+- **`extra.direction`**: the search [direction](#portaldirection)
+- **`extra.distance`**: the absolute distance between the start and current jumplist entry
+- **`:select()`**: uses native `<c-o>` and `<c-i>` to preserve jumplist ordering
 
 <details>
 <summary><b>Examples</b></summary>
@@ -317,7 +317,7 @@ Filter, match, and iterate over Neovim's [`:h quickfix`](http://neovim.io/doc/us
 - **`type`**: `"quickfix"`
 - **`buffer`**: the quickfix `bufnr`
 - **`cursor`**: the quickfix `lnum` and `col`
-- **`select`**: uses `nvim_win_set_cursor` for selection
+- **`:select()`**: uses `nvim_win_set_cursor` for selection
 
 <details>
 <summary><b>Examples</b></summary>
@@ -356,7 +356,7 @@ local search_results = require("portal").search({
 
 -- Select the first location from the list of results
 local first_portal = search_results[1]
-first_portal.select()
+first_portal:select()
 ```
 
 </details>
@@ -603,15 +603,15 @@ Named tuple of `(source, slots)`. Used as the input to [`portal#tunnel`](#portal
 
 ### `Portal.Content`
 
-Named tuple of `(type, buffer, cursor, select)` used in opening and selecting a portal location. **May contain** any additional data to aide in filtering, querying, and selecting a portal. See the [builtins](#builtin-queries) section for information on which additional fields are present.
+A object with the fields `(type, buffer, cursor)` and a `:select()` method used for opening and selecting a portal location. Extra data is available in the `extra` field and can be used to aide in filtering, querying, and selecting a portal. See the [builtins](#builtin-queries) section for information on which additional fields are present.
 
 **Type**: `table`
 
 - **`type`**: `string`
 - **`buffer`**: `integer`
 - **`cursor`**: `{ row: integer, col: integer }`
-- **`select`**: `fun(c: Portal.Content)`
-- **anything else**
+- **`extra`**: `{ row: integer, col: integer }`
+- **`:select()`**: `fun(c: Portal.Content)`
 
 ### `Portal.Predicate`
 

--- a/lua/portal.lua
+++ b/lua/portal.lua
@@ -59,7 +59,7 @@ function Portal.tunnel(queries)
     local results = Portal.search(queries)
 
     if Settings.select_first and #results == 1 then
-        results[1].select(results[1])
+        results[1]:select()
         return
     end
 

--- a/lua/portal/builtin/changelist.lua
+++ b/lua/portal/builtin/changelist.lua
@@ -1,5 +1,6 @@
 ---@type Portal.QueryGenerator
 local function generate(opts, settings)
+    local Content = require("portal.content")
     local Iterator = require("portal.iterator")
     local Search = require("portal.search")
 
@@ -30,20 +31,22 @@ local function generate(opts, settings)
     end
 
     iter = iter:map(function(v, i)
-        return {
+        return Content:new({
             type = "changelist",
             buffer = 0,
             cursor = { row = v.lnum, col = v.col },
-            select = function(content)
+            callback = function(content)
                 local keycode = vim.api.nvim_replace_termcodes("g;", true, false, true)
-                if content.direction == "forward" then
+                if content.extra.direction == "forward" then
                     keycode = vim.api.nvim_replace_termcodes("g,", true, false, true)
                 end
-                vim.api.nvim_feedkeys(content.distance .. keycode, "n", false)
+                vim.api.nvim_feedkeys(content.extra.distance .. keycode, "n", false)
             end,
-            direction = opts.direction,
-            distance = math.abs(opts.start - i),
-        }
+            extra = {
+                direction = opts.direction,
+                distance = math.abs(opts.start - i),
+            },
+        })
     end)
 
     iter = iter:filter(function(v)

--- a/lua/portal/builtin/grapple.lua
+++ b/lua/portal/builtin/grapple.lua
@@ -1,5 +1,6 @@
 ---@type Portal.QueryGenerator
 local function generator(opts, settings)
+    local Content = require("portal.content")
     local Iterator = require("portal.iterator")
     local Search = require("portal.search")
 
@@ -46,15 +47,17 @@ local function generator(opts, settings)
             return nil
         end
 
-        return {
+        return Content:new({
             type = "grapple",
             buffer = buffer,
             cursor = { row = v.cursor[1], col = v.cursor[2] },
-            select = function(content)
-                require("grapple").select({ key = content.key })
+            callback = function(content)
+                require("grapple").select({ key = content.extra.key })
             end,
-            key = v.key,
-        }
+            extra = {
+                key = v.key,
+            },
+        })
     end)
 
     iter = iter:filter(function(v)

--- a/lua/portal/builtin/harpoon.lua
+++ b/lua/portal/builtin/harpoon.lua
@@ -1,5 +1,6 @@
 ---@type Portal.QueryGenerator
 local function generator(opts, settings)
+    local Content = require("portal.content")
     local Iterator = require("portal.iterator")
     local Search = require("portal.search")
 
@@ -42,15 +43,17 @@ local function generator(opts, settings)
             return nil
         end
 
-        return {
+        return Content:new({
             type = "harpoon",
             buffer = buffer,
             cursor = { row = v.row, col = v.col },
-            select = function(content)
-                require("harpoon.ui").nav_file(content.index)
+            callback = function(content)
+                require("harpoon.ui").nav_file(content.extra.index)
             end,
-            index = i,
-        }
+            extra = {
+                index = i,
+            },
+        })
     end)
 
     iter = iter:filter(function(v)

--- a/lua/portal/builtin/jumplist.lua
+++ b/lua/portal/builtin/jumplist.lua
@@ -1,5 +1,6 @@
 ---@type Portal.QueryGenerator
 local function generate(opts, settings)
+    local Content = require("portal.content")
     local Iterator = require("portal.iterator")
     local Search = require("portal.search")
 
@@ -30,20 +31,22 @@ local function generate(opts, settings)
     end
 
     iter = iter:map(function(v, i)
-        return {
+        return Content:new({
             type = "jumplist",
             buffer = v.bufnr,
             cursor = { row = v.lnum, col = v.col },
-            select = function(content)
+            callback = function(content)
                 local keycode = vim.api.nvim_replace_termcodes("<c-o>", true, false, true)
-                if content.direction == "forward" then
+                if content.extra.direction == "forward" then
                     keycode = vim.api.nvim_replace_termcodes("<c-i>", true, false, true)
                 end
-                vim.api.nvim_feedkeys(content.distance .. keycode, "n", false)
+                vim.api.nvim_feedkeys(content.extra.distance .. keycode, "n", false)
             end,
-            direction = opts.direction,
-            distance = math.abs(opts.start - i),
-        }
+            extra = {
+                direction = opts.direction,
+                distance = math.abs(opts.start - i),
+            },
+        })
     end)
 
     iter = iter:filter(function(v)

--- a/lua/portal/builtin/quickfix.lua
+++ b/lua/portal/builtin/quickfix.lua
@@ -1,5 +1,6 @@
 ---@type Portal.QueryGenerator
 local function generator(opts, settings)
+    local Content = require("portal.content")
     local Iterator = require("portal.iterator")
     local Search = require("portal.search")
 
@@ -26,15 +27,15 @@ local function generator(opts, settings)
     end
 
     iter = iter:map(function(v, _)
-        return {
+        return Content:new({
             type = "quickfix",
             buffer = v.bufnr,
             cursor = { row = v.lnum, col = v.col },
-            select = function(content)
+            callback = function(content)
                 vim.api.nvim_win_set_buf(0, content.buffer)
                 vim.api.nvim_win_set_cursor(0, { content.cursor.row, content.cursor.col })
             end,
-        }
+        })
     end)
 
     iter = iter:filter(function(v)

--- a/lua/portal/content.lua
+++ b/lua/portal/content.lua
@@ -1,0 +1,31 @@
+---@class Portal.Content
+---@field type string
+---@field buffer integer
+---@field cursor { row: integer, col: integer }
+---@field callback fun(c: Portal.Content)
+---@field extra table
+local Content = {}
+Content.__index = Content
+
+function Content:new(content)
+    assert(content.buffer, ("Portal: invalid content.buffer %s"):format(vim.inspect(content.buffer)))
+    assert(
+        content.cursor and content.cursor.row and content.cursor.col,
+        ("Portal: invalid content.cursor %s"):format(vim.inspect(content.cursor))
+    )
+    assert(
+        type(content.callback) == "function",
+        ("Portal: invalid content.callback %s"):format(vim.inspect(content.callback))
+    )
+
+    content.extra = content.extra or {}
+    setmetatable(content, self)
+
+    return content
+end
+
+function Content:select()
+    return self.callback(self)
+end
+
+return Content

--- a/lua/portal/window.lua
+++ b/lua/portal/window.lua
@@ -7,12 +7,6 @@ local log = require("portal.log")
 local Window = {}
 Window.__index = Window
 
----@class Portal.Content
----@field type string
----@field buffer integer
----@field cursor { row: integer, col: integer }
----@field select fun(c: Portal.Content)
-
 ---@class Portal.WindowOptions
 ---@field title string
 ---@field relative string
@@ -41,21 +35,14 @@ vim.api.nvim_set_hl(0, "PortalNormal", { link = "NormalFloat", default = true })
 ---@param options Portal.WindowOptions
 ---@return Portal.Window
 function Window:new(content, options)
-    if not content.buffer or not vim.api.nvim_buf_is_valid(content.buffer) then
-        log.error(("Window.new: invalid buffer %s"):format(content.buffer))
-    end
-    if not content.cursor or not content.cursor.row or not content.cursor.col then
-        log.error(("Window.new: cursor is not present or valid in %s"):format(vim.inspect(content)))
-    end
-    if not content.select then
-        log.error(("Window.new: select is not present."):format(vim.inspect(content)))
-    end
+    assert(vim.api.nvim_buf_is_valid(content.buffer), ("Portal: invalid buffer %s"):format(content.buffer))
 
     local window = {
         content = content,
         options = options,
         state = nil,
     }
+
     setmetatable(window, self)
     return window
 end
@@ -147,7 +134,7 @@ function Window:select()
         log.warn("Window.select: window is not open.")
         return
     end
-    self.content.select(self.content)
+    self.content:select()
 end
 
 function Window:close()


### PR DESCRIPTION
### Context

The `Portal.Content` is a small data structure for passing around necessary "location" information. This refactor addresses a couple problems with the current approach:
- `Portal.Window` was validating the content, which it shouldn't have to
- `Portal.Search` returned a list of `Portal.Content` location to the user, they shouldn't _need_ to know the details of invoking the callback
- Extra fields were being thrown in alongside essential content data

### Changes

- **BREAKING** `Portal.Content` additional data is now contained in a nested `extra` field
- Refactor `Portal.Content` as a class
  - `Content:new` wraps and validates an input table as a content object
  - `Content:select` invokes the content's `callback`
- Propagate refactor into builtins
- Propagate refactor into window and remove redundant validations
- Update README