### PR TITLE
fix(docs): use string.find(plain) instead of string.match

### DIFF
--- a/README.md
+++ b/README.md
@@ -429,7 +429,7 @@ require("portal.builtin").jumplist({
         if #root_files > 0 then
             local root_dir = vim.fs.dirname(root_files[1])
             local file_path = vim.api.nvim_buf_get_name(v.buffer)
-            return string.match(file_path, ("^%s"):format(root_dir)) ~= nil
+            return string.find(file_path, root_dir, 1, true) ~= nil
         end
         return true
     end

--- a/doc/portal.nvim.txt
+++ b/doc/portal.nvim.txt
@@ -461,7 +461,7 @@ Examples ~
             if root_files > 0 then
                 local root_dir = vim.fs.dirname(root_files[1])
                 local file_path = vim.api.nvim_buf_get_name(v.buffer)
-                return string.find(file_path, root_dir, 1, true) ~= nil
+                return string.match(file_path, ("^%s"):format(root_dir)) ~= nil
             end
             return true
         end

--- a/doc/portal.nvim.txt
+++ b/doc/portal.nvim.txt
@@ -461,7 +461,7 @@ Examples ~
             if root_files > 0 then
                 local root_dir = vim.fs.dirname(root_files[1])
                 local file_path = vim.api.nvim_buf_get_name(v.buffer)
-                return string.match(file_path, ("^%s"):format(root_dir)) ~= nil
+                return string.find(file_path, root_dir, 1, true) ~= nil
             end
             return true
         end


### PR DESCRIPTION
A `root_dir` might contain special characters `.` or `-` which are not literal in lua patterns. Use the `plain` argument to `string.find` to match a plain string rather than a pattern.

https://www.lua.org/manual/5.4/manual.html#pdf-string.find